### PR TITLE
Hide jump to without results, style horizontal scrolling

### DIFF
--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -21,7 +21,6 @@ class SearchInput extends Component {
           type="text"
           placeholder="Search"
           onChange={event => {
-            console.log("here");
             this.setState({ input: event.target.value });
             this.props.performSearch(event.target.value);
           }}

--- a/src/containers/SearchContainer/index.js
+++ b/src/containers/SearchContainer/index.js
@@ -85,6 +85,21 @@ class SearchContainer extends Component {
     }
   }
 
+  _renderBottomBar() {
+    return (
+      <div className="SearchContainer__bottom">
+        <div className="SearchContainer__bottom__jump">
+          <span>Jump to...</span>
+          {this.props.current_set.map((item, i) => (
+            <a className="animated fadeIn" key={i} href={`#${item.number}`}>
+              {item.abbreviation} {item.number}
+            </a>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
   render() {
     return (
       <div className="SearchContainer">
@@ -93,16 +108,7 @@ class SearchContainer extends Component {
           <SearchInput performSearch={this._performSearch.bind(this)} />
         </div>
 
-        <div className="SearchContainer__bottom">
-          <div className="SearchContainer__bottom__jump">
-            <span>Jump to...</span>
-            {this.props.current_set.map((item, i) => (
-              <a className="animated fadeIn" key={i} href={`#${item.number}`}>
-                {item.abbreviation} {item.number}
-              </a>
-            ))}
-          </div>
-        </div>
+        { this.props.current_set.length > 0 ? this._renderBottomBar() : null }
 
         <div className="SearchContainer__tools">
           Tools and tool buttons will go here

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,6 @@ ReactDOM.render(
 
 if (module.hot) {
   module.hot.accept("./containers/AppContainer", () => {
-    console.log("Reload pls?");
     const NextApp = require("./containers/AppContainer").default;
     ReactDOM.render(
       <Provider store={store}>

--- a/src/redux/utils/store.js
+++ b/src/redux/utils/store.js
@@ -3,9 +3,6 @@ import { enableBatching } from "redux-batched-actions";
 import thunk from "redux-thunk";
 import { apiMiddleware } from 'redux-api-middleware';
 
-console.log(thunk)
-console.log(apiMiddleware)
-
 import reducers from "./reducers";
 import DevTools from "./devtools";
 

--- a/src/styles/results.sass
+++ b/src/styles/results.sass
@@ -1,5 +1,5 @@
 .ResultsContainer
-  padding-top: 155px
+  padding-top: 180px
 
 .Course
   max-width: 750px
@@ -35,12 +35,12 @@
 
     &__name
       max-width: 400px
-      
+
       > h1
         font-size: 3.6rem
         > span
           font-weight: 800
-      
+
       > h2
         padding-top: 5px
         color: gray
@@ -96,12 +96,12 @@
 
   &__content
     flex-grow: 1
-    
+
   &__intervals
     display: flex
     flex-direction: column
     justify-content: center
-  
+
   &__container
     display: flex
     flex-direction: row
@@ -144,7 +144,7 @@
       .number
         color: black
         font-size: 2.6rem
-  
+
 .StudentCounter
   display: flex
   flex-direction: column
@@ -257,13 +257,13 @@
       &__container
         display: flex
         align-items: center
-        
+
         > h3
           font-size: 0.7rem
           text-transform: uppercase
           margin-right: 12px
           color: gray
-          
+
         > img
           $size: 24px
           width: $size

--- a/src/styles/results.sass
+++ b/src/styles/results.sass
@@ -1,5 +1,6 @@
 .ResultsContainer
-  padding-top: 180px
+  padding-top: 12rem
+  padding-bottom: 5rem
 
 .Course
   max-width: 750px

--- a/src/styles/searching.sass
+++ b/src/styles/searching.sass
@@ -25,7 +25,7 @@
 
   input
     background: none
-  
+
   &__tools
     position: absolute
     top: 80px
@@ -108,5 +108,5 @@
     &:focus
       // We can experiment with this later
       // padding: 33px 50px
-      // font-size: 2.5em 
+      // font-size: 2.5em
       outline: none

--- a/src/styles/searching.sass
+++ b/src/styles/searching.sass
@@ -50,7 +50,7 @@
       z-index: -1;
 
   &__bottom
-    height: 50px
+    height: 75px
     background-color: transparentize(lighten(gray, 46), 0.2)
     border-top: 1px solid lighten(gray, 37)
     border-bottom: 1px solid lighten(gray, 37)
@@ -63,6 +63,10 @@
     &__jump
       display: flex
       align-items: center
+      overflow-x: scroll
+      overflow-y: hidden
+      white-space: nowrap
+      height: 75px
 
       > span
         min-width: 120px
@@ -76,7 +80,7 @@
         background: white
         color: darken(gray, 10)
         border-radius: 8px
-        margin: 10px 5px
+        margin: 5px
         padding: 7px 4px
         text-decoration: none
         box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.14)


### PR DESCRIPTION
This PR does 2 things:
- Hides "jump to" section unless results are available
- Styles horizontal scrolling for the "jump to" section

<img width="1634" alt="screen shot 2017-03-25 at 11 05 54 am" src="https://cloud.githubusercontent.com/assets/13528491/24323944/6668a140-114b-11e7-915f-3b214d003c95.png">
