### PR TITLE
CSS work: responsive, intervals, emblems, instructors

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js --env=jsdom"
+    "test": "node scripts/test.js --env=jsdom",
+    "heroku-prebuild": "npm rebuild node-sass"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/components/Results/Interval.js
+++ b/src/components/Results/Interval.js
@@ -33,67 +33,125 @@ const Interval = (
     s_svc,
     comments
   }
-) => (
-  <div className="Interval">
+) => {
+  const emblems = genEmblems({
+    s_night,
+    s_all_web,
+    s_most_web,
+    s_half_web,
+    s_some_web,
+    is_lab,
+    s_cmi_spoken,
+    s_cmi_tech,
+    s_cmi_written,
+    s_cmi_visual,
+    s_majors_only,
+    s_req_dept_perm,
+    s_req_inst_perm,
+    comments
+  });
 
-    <div className="Interval__top Interval__portion">
-      <div className="Interval__dates">
-        <div className="Dates">
-          {generateInfoOverlay(is_lab, has_time, "lab")}
-          {generateInfoOverlay(s_all_web, has_time, "web")}
-          <div className={generateClass("MONDAY", days)}>M</div>
-          <div className={generateClass("TUESDAY", days)}>T</div>
-          <div className={generateClass("WEDNESDAY", days)}>W</div>
-          <div className={generateClass("THURSDAY", days)}>T</div>
-          <div className={generateClass("FRIDAY", days)}>F</div>
+  return (
+    <div className="Interval">
+
+      <div className="Interval__top Interval__portion">
+        <div className="Interval__dates">
+          <div className="Dates">
+            {generateInfoOverlay(is_lab, has_time, "lab")}
+            {generateInfoOverlay(s_all_web, has_time, "web")}
+            <div className={generateClass("MONDAY", days)}>M</div>
+            <div className={generateClass("TUESDAY", days)}>T</div>
+            <div className={generateClass("WEDNESDAY", days)}>W</div>
+            <div className={generateClass("THURSDAY", days)}>T</div>
+            <div className={generateClass("FRIDAY", days)}>F</div>
+          </div>
+        </div>
+
+        <div className="Interval__info">
+
+          {has_time
+            ? <div className="Interval__info__time">
+                <span>{formatTime(start)}</span>
+                {" "}
+                →
+                {" "}
+                <span>{formatTime(end)}</span>
+              </div>
+            : <div className="Interval__info__time tba">Time TBA</div>}
+
+          {location_building || location_room
+            ? <div className="Interval__info__location">
+                <span className="room">{location_room + " "}</span>
+                <span className="building">
+                  {Case.capital(location_building)}
+                </span>
+              </div>
+            : <div className="Interval__info__location tba">Location TBA</div>}
+
+        </div>
+
+        <div className="Interval__instructors">
+          {instructor[0].name !== ""
+            ? instructor.map((inst, i) => (
+                <p key={i}>{formatInstructor(inst)}</p>
+              ))
+            : <p className="none">No Instructor Listed</p>}
         </div>
       </div>
 
-      <div className="Interval__info">
-
-        {has_time
-          ? <div className="Interval__info__time">
-              <span>{formatTime(start)}</span> → <span>{formatTime(end)}</span>
+      {emblems.length > 0
+        ? <div className="Interval__bottom Interval__portion">
+            <div className="Interval__emblems">
+              {emblems.map((Emblem, i) => <span key={i}>{Emblem}</span>)}
             </div>
-          : <div className="Interval__info__time tba">Time TBA</div>}
-
-        {location_building || location_room
-          ? <div className="Interval__info__location">
-              <span className="room">{location_room + " "}</span>
-              <span className="building">
-                {Case.capital(location_building)}
-              </span>
-            </div>
-          : <div className="Interval__info__location tba">Location TBA</div>}
-
-      </div>
-
-      <div className="Interval__instructors">
-        {instructor.map((inst, i) => <p key={i}>{formatInstructor(inst)}</p>)}
-      </div>
+          </div>
+        : undefined}
     </div>
+  );
+};
 
-    <div className="Interval__bottom Interval__portion">
-      <div className="Interval__emblems">
-        {s_night && getEmblem("night")}
-        {is_lab && getEmblem("lab")}
-        {/*s_cmi && getEmblem("cmi")*/}
-        {s_cmi_spoken && getEmblem("cmi_spoken")}
-        {s_cmi_written && getEmblem("cmi_written")}
-        {s_cmi_visual && getEmblem("cmi_visual")}
-        {s_cmi_tech && getEmblem("cmi_tech")}
-        {s_majors_only && getEmblem("majors_only")}
-        {s_all_web && getEmblem("all_web")}
-        {s_most_web && getEmblem("most_web")}
-        {s_half_web && getEmblem("half_web")}
-        {s_some_web && getEmblem("some_web")}
-      </div>
-    </div>
-  </div>
-);
+function genEmblems(
+  {
+    s_night,
+    s_all_web,
+    s_most_web,
+    s_half_web,
+    s_some_web,
+    is_lab,
+    s_cmi_spoken,
+    s_cmi_tech,
+    s_cmi_written,
+    s_cmi_visual,
+    s_majors_only,
+    s_req_dept_perm,
+    s_req_inst_perm,
+    comments
+  }
+) {
+  let emblems = [];
+
+  if (s_night) emblems.push(getEmblem("night"));
+  if (is_lab) emblems.push(getEmblem("lab"));
+  if (s_cmi_spoken) emblems.push(getEmblem("cmi_spoken"));
+  if (s_cmi_written) emblems.push(getEmblem("cmi_written"));
+  if (s_cmi_visual) emblems.push(getEmblem("cmi_visual"));
+  if (s_cmi_tech) emblems.push(getEmblem("cmi_tech"));
+  if (s_all_web) emblems.push(getEmblem("all_web"));
+  if (s_most_web) emblems.push(getEmblem("most_web"));
+  if (s_some_web) emblems.push(getEmblem("some_web"));
+  if (s_half_web) emblems.push(getEmblem("half_web"));
+  if (s_majors_only) emblems.push(getEmblem("majors_only"));
+  if (s_req_dept_perm) emblems.push(getEmblem("req_dept_perm"));
+  if (s_req_inst_perm) emblems.push(getEmblem("req_inst_perm"));
+  if (comments.length > 0) emblems.push(getEmblem("comments"));
+
+  return emblems;
+}
 
 function getEmblem(type) {
   let tooltipID = type + "-tooltip";
+  let imgSrc = getIconSrc(type);
+  let title = getEmblemTitle(type);
 
   return (
     <div className="emblem">
@@ -105,16 +163,16 @@ function getEmblem(type) {
         delayShow={0}
       >
         <div className="emblem__tooltip__internal">
-          <img src={getIconSrc(type)} alt="emblem" />
+          <img src={imgSrc} alt="emblem" />
           <div>
-            <h3>{getEmblemTitle(type)}</h3><p>{getEmblemText(type)}</p>
+            <h3>{title}</h3><p>{getEmblemText(type)}</p>
           </div>
         </div>
       </Tooltip>
 
       <div className="emblem__container" data-tip data-for={tooltipID}>
-        <img src={getIconSrc(type)} alt="emblem" />
-        <h3>{getEmblemTitle(type)}</h3>
+        <img src={imgSrc} alt="emblem" />
+        <h3>{title}</h3>
       </div>
 
     </div>
@@ -139,6 +197,9 @@ function getEmblemTitle(type) {
   if (type === "cmi_tech") return "Intesive: Technical";
   if (type === "cmi_visual") return "Intesive: Visual";
   if (type === "majors_only") return "Majors Only";
+  if (type === "req_dept_perm") return "Req. Department Perm.";
+  if (type === "req_inst_perm") return "Req. Instructor Perm.";
+  if (type === "comments") return "Has Comments";
   if (type === "all_web") return "Online";
   if (type === "most_web") return "Mostly Online";
   if (type === "half_web") return "Half Online";

--- a/src/styles/results.sass
+++ b/src/styles/results.sass
@@ -315,6 +315,11 @@
     border-top: 1px dashed lighten(gray, 37)
 
   &__instructors
+
+    .none
+      font-size: 0.9rem
+      color: lighten(gray, 10)
+
     @media (max-width: 750px)
       text-align: center
       color: gray


### PR DESCRIPTION
This updates the emblem and instructor display algorithms to not only be more idiomatic in a React sense, but to also be quite a bit more performant. Also helps hide the empty emblem block that was taking up a lot of vertical space on mobile when displays intervals that had no emblems but still had an empty emblem div.

Cleans up and tightens the spacing quite a bit.

![image](https://cloud.githubusercontent.com/assets/1844458/24347819/45d3d076-129f-11e7-9f7b-30c493d641a5.png)

![image](https://cloud.githubusercontent.com/assets/1844458/24347940/a027c280-129f-11e7-8997-404d54d428ae.png)
