### PR TITLE
Fix data-id problem with tooltips, restyle

### DIFF
--- a/src/components/Results/CourseDescription.js
+++ b/src/components/Results/CourseDescription.js
@@ -29,8 +29,6 @@ const CourseDescription = ({ description, comments }) => (
       <span className="content">{description}</span>
     </div>
 
-    {/* TODO: Maybe use component state to allow for a "Read More..." on the comment section. And shorten it. */}
-
     {comments.length > 0
       ? <div className="CourseDescription__comments">
           <span className="title">Comments</span>

--- a/src/components/Results/Interval.js
+++ b/src/components/Results/Interval.js
@@ -149,11 +149,12 @@ function genEmblems(
 }
 
 function getEmblem(type, comments) {
-  let tooltipID = type + "-tooltip";
+  let tooltipID = type + "-tooltip-" + Math.floor(Math.random() * 50);
   let imgSrc = getIconSrc(type);
   let title = getEmblemTitle(type, comments);
 
-  if (comments !== undefined) tooltipID = type + "-tooltip" + comments[0];
+  if (comments !== undefined)
+    tooltipID += Math.floor(Math.random() * 50);
 
   return (
     <div className="emblem">
@@ -161,6 +162,7 @@ function getEmblem(type, comments) {
       <Tooltip
         className="eblem__tooltip"
         id={tooltipID}
+        data-id={tooltipID}
         effect="solid"
         delayShow={0}
       >
@@ -219,12 +221,18 @@ function getEmblemText(type, comments) {
   if (type === "night") return "The day(s) above are held at night.";
   if (type === "lab") return "The day(s) above are a lab.";
   if (type === "cmi") return "The day(s) above are communication intensive.";
-  if (type === "cmi_written") return "Writing";
+  if (type === "cmi_written")
+    return "Course features intensive writing activities.";
+  if (type === "cmi_spoken")
+    return "Course features intensive speaking activities.";
+  if (type === "cmi_technical")
+    return "Course features intensive technical activities.";
   if (type === "majors_only") return "The day(s) above are for majors only.";
   if (type === "all_web") return "The day(s) above are entirely online.";
   if (type === "most_web") return "The day(s) above are mostly online.";
-  if (type === "half_web") return "";
-  if (type === "some_web") return "";
+  if (type === "half_web") return "The day(s) above are about half online.";
+  if (type === "some_web")
+    return "The day(s) above feature some online content.";
   if (type === "comments") return comments + "";
   return "No specific details";
 }

--- a/src/styles/results.sass
+++ b/src/styles/results.sass
@@ -355,23 +355,32 @@
 
       .__react_component_tooltip
         padding: 0
-        border-radius: 8px
-        background-color: black !important
+        border-radius: 10px
+        background-color: transparentize(white, 0.07) !important
+        box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)
+        color: black
+        -webkit-backdrop-filter: blur(4px) !important
+        backdrop-filter: blur(4px) !important
+
+        &:after
+          border-top-color: transparentize(white, 0.07) !important
+
+        &:before
+          border-top-color: transparentize(white, 0.07) !important
 
       &__tooltip
 
         &__internal
-          padding: 10px
+          padding: 15px
           display: flex
           flex-direction: row
 
           > div
-            padding-left: 10px
+            padding-left: 15px
 
             h3
               font-weight: 800
-              text-transform: uppercase
-              font-size: 0.8rem
+              font-size: 1.2rem
               padding-bottom: 6px
 
           > img


### PR DESCRIPTION
This re-styles tooltips and ensures that each have a unique data-id so that they do not render over each other. This greatly increases performance.

![image](https://cloud.githubusercontent.com/assets/1844458/24419664/87922b86-13b5-11e7-8136-50a170517de0.png)
